### PR TITLE
fix: duplicate message filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .xcall-multi
 artifacts
 vendor
+.artifacts/
+.xcall/

--- a/relayer/chain_runtime.go
+++ b/relayer/chain_runtime.go
@@ -56,12 +56,12 @@ func (dst *ChainRuntime) shouldSendMessage(ctx context.Context, routeMessage *ty
 		return false
 	}
 
-	ok, _ := dst.Provider.ShouldReceiveMessage(ctx, *routeMessage.Message)
+	ok, _ := dst.Provider.ShouldReceiveMessage(ctx, routeMessage.Message)
 	if !ok {
 		return false
 	}
 
-	ok, _ = src.Provider.ShouldSendMessage(ctx, *routeMessage.Message)
+	ok, _ = src.Provider.ShouldSendMessage(ctx, routeMessage.Message)
 	if !ok {
 		return false
 	}

--- a/relayer/chain_runtime.go
+++ b/relayer/chain_runtime.go
@@ -58,6 +58,7 @@ func (dst *ChainRuntime) shouldSendMessage(ctx context.Context, routeMessage *ty
 
 	ok, _ := dst.Provider.ShouldReceiveMessage(ctx, routeMessage.Message)
 	if !ok {
+		dst.log.Info("message already processed", zap.Uint64("sn", routeMessage.Message.Sn))
 		return false
 	}
 

--- a/relayer/chains/evm/query.go
+++ b/relayer/chains/evm/query.go
@@ -18,30 +18,29 @@ func (p *EVMProvider) QueryLatestHeight(ctx context.Context) (height uint64, err
 	return
 }
 
-func (p *EVMProvider) QueryBalance(ctx context.Context, addr string) (*providerTypes.Coin, error) {
-	//TODO:
-	return nil, nil
-}
-
-func (p *EVMProvider) ShouldReceiveMessage(ctx context.Context, messagekey types.Message) (bool, error) {
+func (p *EVMProvider) ShouldReceiveMessage(ctx context.Context, msg *types.Message) (bool, error) {
 	return true, nil
 }
 
-func (p *EVMProvider) ShouldSendMessage(ctx context.Context, messageKey types.Message) (bool, error) {
-	return true, nil
+func (p *EVMProvider) ShouldSendMessage(ctx context.Context, msg *types.Message) (bool, error) {
+	received, err := p.MessageReceived(ctx, msg)
+	if err != nil {
+		return false, fmt.Errorf("ShouldSendMessage: %v", err)
+	}
+	return !received, nil
 }
 
-func (p *EVMProvider) MessageReceived(ctx context.Context, messageKey types.MessageKey) (bool, error) {
-	return p.client.MessageReceived(nil, messageKey.Src, big.NewInt(int64(messageKey.Sn)))
+func (p *EVMProvider) MessageReceived(ctx context.Context, msg *types.Message) (bool, error) {
+	return p.client.MessageReceived(nil, msg.Src, big.NewInt(int64(msg.Sn)))
 }
 
-// func (p *EVMProvider) QueryBalance(ctx context.Context, addr string) (*types.Coin, error) {
-// 	balance, err := p.client.GetBalance(ctx, addr)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return &types.Coin{Amount: balance.Uint64(), Denom: "eth"}, nil
-// }
+func (p *EVMProvider) QueryBalance(ctx context.Context, addr string) (*types.Coin, error) {
+	balance, err := p.client.GetBalance(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	return &types.Coin{Amount: balance.Uint64(), Denom: "eth"}, nil
+}
 
 // TODO: may not be need anytime soon so its ok to implement later on
 func (ip *EVMProvider) GenerateMessage(ctx context.Context, key *providerTypes.MessageKeyWithMessageHeight) (*providerTypes.Message, error) {

--- a/relayer/chains/evm/query.go
+++ b/relayer/chains/evm/query.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/icon-project/centralized-relay/relayer/types"
 	providerTypes "github.com/icon-project/centralized-relay/relayer/types"
+	"go.uber.org/zap"
 )
 
 func (p *EVMProvider) QueryLatestHeight(ctx context.Context) (height uint64, err error) {
@@ -21,7 +22,8 @@ func (p *EVMProvider) QueryLatestHeight(ctx context.Context) (height uint64, err
 func (p *EVMProvider) ShouldReceiveMessage(ctx context.Context, msg *types.Message) (bool, error) {
 	processed, err := p.MessageReceived(ctx, msg)
 	if err != nil {
-		return false, fmt.Errorf("ShouldReceiveMessage: %v", err)
+		p.log.Error("failed checking receipt", zap.Error(err))
+		return false, err
 	}
 	return !processed, nil
 }

--- a/relayer/chains/evm/query.go
+++ b/relayer/chains/evm/query.go
@@ -19,15 +19,15 @@ func (p *EVMProvider) QueryLatestHeight(ctx context.Context) (height uint64, err
 }
 
 func (p *EVMProvider) ShouldReceiveMessage(ctx context.Context, msg *types.Message) (bool, error) {
-	return true, nil
+	processed, err := p.MessageReceived(ctx, msg)
+	if err != nil {
+		return false, fmt.Errorf("ShouldReceiveMessage: %v", err)
+	}
+	return !processed, nil
 }
 
 func (p *EVMProvider) ShouldSendMessage(ctx context.Context, msg *types.Message) (bool, error) {
-	received, err := p.MessageReceived(ctx, msg)
-	if err != nil {
-		return false, fmt.Errorf("ShouldSendMessage: %v", err)
-	}
-	return !received, nil
+	return true, nil
 }
 
 func (p *EVMProvider) MessageReceived(ctx context.Context, msg *types.Message) (bool, error) {

--- a/relayer/chains/icon/query.go
+++ b/relayer/chains/icon/query.go
@@ -22,7 +22,6 @@ func callParamsWithHeight(height types.HexInt) CallParamOption {
 }
 
 func (ip *IconProvider) prepareCallParams(methodName string, param map[string]interface{}, options ...CallParamOption) *types.CallParam {
-
 	callData := &types.CallData{
 		Method: methodName,
 		Params: param,
@@ -40,7 +39,6 @@ func (ip *IconProvider) prepareCallParams(methodName string, param map[string]in
 	}
 
 	return callParam
-
 }
 
 func (ip *IconProvider) QueryLatestHeight(ctx context.Context) (uint64, error) {
@@ -51,20 +49,22 @@ func (ip *IconProvider) QueryLatestHeight(ctx context.Context) (uint64, error) {
 	return uint64(block.Height), nil
 }
 
-func (ip *IconProvider) ShouldReceiveMessage(ctx context.Context, messagekey providerTypes.Message) (bool, error) {
+func (ip *IconProvider) ShouldReceiveMessage(ctx context.Context, messagekey *providerTypes.Message) (bool, error) {
 	return true, nil
-
-}
-func (ip *IconProvider) ShouldSendMessage(ctx context.Context, messageKey providerTypes.Message) (bool, error) {
-	return true, nil
-
 }
 
-func (ip *IconProvider) MessageReceived(ctx context.Context, messageKey providerTypes.MessageKey) (bool, error) {
+func (ip *IconProvider) ShouldSendMessage(ctx context.Context, messageKey *providerTypes.Message) (bool, error) {
+	received, err := ip.MessageReceived(ctx, messageKey)
+	if err != nil {
+		return false, fmt.Errorf("ShouldSendMessage: %v", err)
+	}
+	return !received, nil
+}
 
+func (ip *IconProvider) MessageReceived(ctx context.Context, message *providerTypes.Message) (bool, error) {
 	callParam := ip.prepareCallParams(MethodGetReceipts, map[string]interface{}{
-		"srcNetwork": messageKey.Src,
-		"_connSn":    types.NewHexInt(int64(messageKey.Sn)),
+		"srcNetwork": message.Src,
+		"_connSn":    types.NewHexInt(int64(message.Sn)),
 	})
 
 	var status types.HexInt
@@ -98,7 +98,7 @@ func (ip *IconProvider) GenerateMessage(ctx context.Context, key *providerTypes.
 		return nil, errors.New("GenerateMessage: message key cannot be nil")
 	}
 
-	var eventName = ""
+	eventName := ""
 	switch key.EventType {
 	case events.EmitMessage:
 		eventName = EmitMessage
@@ -173,7 +173,6 @@ func (icp *IconProvider) QueryTransactionReceipt(ctx context.Context, txHash str
 	status, err := res.Status.Int()
 	if err != nil {
 		return nil, fmt.Errorf("QueryTransactionReceipt: bigIntConversion %v", err)
-
 	}
 
 	receipt := providerTypes.Receipt{
@@ -184,5 +183,4 @@ func (icp *IconProvider) QueryTransactionReceipt(ctx context.Context, txHash str
 		receipt.Status = true
 	}
 	return &receipt, nil
-
 }

--- a/relayer/chains/icon/query.go
+++ b/relayer/chains/icon/query.go
@@ -49,16 +49,16 @@ func (ip *IconProvider) QueryLatestHeight(ctx context.Context) (uint64, error) {
 	return uint64(block.Height), nil
 }
 
-func (ip *IconProvider) ShouldReceiveMessage(ctx context.Context, messagekey *providerTypes.Message) (bool, error) {
-	return true, nil
+func (ip *IconProvider) ShouldReceiveMessage(ctx context.Context, msg *providerTypes.Message) (bool, error) {
+	processed, err := ip.MessageReceived(ctx, msg)
+	if err != nil {
+		return false, fmt.Errorf("ShouldReceiveMessage: %v", err)
+	}
+	return !processed, nil
 }
 
 func (ip *IconProvider) ShouldSendMessage(ctx context.Context, messageKey *providerTypes.Message) (bool, error) {
-	received, err := ip.MessageReceived(ctx, messageKey)
-	if err != nil {
-		return false, fmt.Errorf("ShouldSendMessage: %v", err)
-	}
-	return !received, nil
+	return true, nil
 }
 
 func (ip *IconProvider) MessageReceived(ctx context.Context, message *providerTypes.Message) (bool, error) {

--- a/relayer/chains/icon/query.go
+++ b/relayer/chains/icon/query.go
@@ -52,7 +52,8 @@ func (ip *IconProvider) QueryLatestHeight(ctx context.Context) (uint64, error) {
 func (ip *IconProvider) ShouldReceiveMessage(ctx context.Context, msg *providerTypes.Message) (bool, error) {
 	processed, err := ip.MessageReceived(ctx, msg)
 	if err != nil {
-		return false, fmt.Errorf("ShouldReceiveMessage: %v", err)
+		ip.log.Error("failed checking receipt", zap.Error(err))
+		return false, err
 	}
 	return !processed, nil
 }

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -28,9 +28,9 @@ type ChainProvider interface {
 	ProviderConfig() ProviderConfig
 	Listener(ctx context.Context, lastSavedHeight uint64, blockInfo chan types.BlockInfo) error
 	Route(ctx context.Context, message *types.Message, callback types.TxResponseFunc) error
-	ShouldReceiveMessage(ctx context.Context, message types.Message) (bool, error)
-	ShouldSendMessage(ctx context.Context, message types.Message) (bool, error)
-	MessageReceived(ctx context.Context, key types.MessageKey) (bool, error)
+	ShouldReceiveMessage(ctx context.Context, msg *types.Message) (bool, error)
+	ShouldSendMessage(ctx context.Context, msg *types.Message) (bool, error)
+	MessageReceived(ctx context.Context, msg *types.Message) (bool, error)
 
 	FinalityBlock(ctx context.Context) uint64
 	GenerateMessage(ctx context.Context, messageKey *types.MessageKeyWithMessageHeight) (*types.Message, error)

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -254,7 +254,7 @@ func (r *Relayer) processMessages(ctx context.Context) {
 			}
 
 			// if message reached delete the message
-			messageReceived, err := dstChainRuntime.Provider.MessageReceived(ctx, routeMessage.MessageKey())
+			messageReceived, err := dstChainRuntime.Provider.MessageReceived(ctx, routeMessage.Message)
 			if err != nil {
 				r.log.Error("processMessage: error occured when checking Message status", zap.Error(err))
 				continue
@@ -284,7 +284,6 @@ func (r *Relayer) processBlockInfo(ctx context.Context, srcChainRuntime *ChainRu
 }
 
 func (r *Relayer) SaveBlockHeight(ctx context.Context, chainRuntime *ChainRuntime, height uint64, messageCount int) error {
-
 	if messageCount > 0 || (height-chainRuntime.LastSavedHeight) > uint64(SaveHeightMaxAfter) {
 		r.log.Debug("saving height:", zap.String("srcChain", chainRuntime.Provider.NID()), zap.Uint64("height", height))
 		chainRuntime.LastSavedHeight = height
@@ -404,11 +403,9 @@ func (r *Relayer) StartFinalityProcessor(ctx context.Context) {
 			r.CheckFinality(ctx)
 		}
 	}
-
 }
 
 func (r *Relayer) CheckFinality(ctx context.Context) {
-
 	for _, c := range r.chains {
 		// check for the finality only if finalityblock is provided by the chain
 		finalityBlock := c.Provider.FinalityBlock(ctx)


### PR DESCRIPTION
Checks for duplicate message before relaying message.

This handles two cases, when message has failed and relayer is unware and abilty to run multiple relayer at once.