### PR TITLE
Store messages in db before pushing it to the message cache

### DIFF
--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -280,12 +280,7 @@ func (r *Relayer) processBlockInfo(ctx context.Context, srcChainRuntime *ChainRu
 		r.log.Error("unable to save height", zap.Error(err))
 	}
 
-	if err := r.messageStore.StoreMessages(blockInfo.Messages); err != nil {
-		r.log.Error(fmt.Sprintf("failed to save messages in db: %v", err))
-	}
-
-	msgStream := r.getMessageStreamAfterSavingToDB(blockInfo.Messages)
-	for msg := range msgStream {
+	for msg := range r.getMessageStreamAfterSavingToDB(blockInfo.Messages) {
 		srcChainRuntime.MessageCache.Add(types.NewRouteMessage(msg))
 	}
 }

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -289,6 +289,7 @@ func (r *Relayer) processBlockInfo(ctx context.Context, srcChainRuntime *ChainRu
 
 func (r *Relayer) getMessageStreamAfterSavingToDB(messages []*types.Message) <-chan *types.Message {
 	msgStream := make(chan *types.Message)
+
 	go func(msgList []*types.Message) {
 		defer close(msgStream)
 		for _, msg := range msgList {

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -280,6 +280,10 @@ func (r *Relayer) processBlockInfo(ctx context.Context, srcChainRuntime *ChainRu
 		r.log.Error("unable to save height", zap.Error(err))
 	}
 
+	if err := r.messageStore.StoreMessages(blockInfo.Messages); err != nil {
+		r.log.Error(fmt.Sprintf("failed to save messages in db: %v", err))
+	}
+
 	go srcChainRuntime.mergeMessages(ctx, blockInfo.Messages)
 }
 

--- a/relayer/store/messageStore.go
+++ b/relayer/store/messageStore.go
@@ -104,6 +104,16 @@ func (ms *MessageStore) StoreMessage(message *types.RouteMessage) error {
 	return ms.db.SetByKey(key, msgByte)
 }
 
+func (ms *MessageStore) StoreMessages(messages []*types.Message) error {
+	for _, message := range messages {
+		routeMessage := types.NewRouteMessage(message)
+		if err := ms.StoreMessage(routeMessage); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (ms *MessageStore) GetMessage(messageKey types.MessageKey) (*types.RouteMessage, error) {
 	v, err := ms.db.GetByKey(GetKey([]string{ms.prefix, messageKey.Src, fmt.Sprintf("%d", messageKey.Sn)}))
 	if err != nil {

--- a/relayer/store/messageStore.go
+++ b/relayer/store/messageStore.go
@@ -104,16 +104,6 @@ func (ms *MessageStore) StoreMessage(message *types.RouteMessage) error {
 	return ms.db.SetByKey(key, msgByte)
 }
 
-func (ms *MessageStore) StoreMessages(messages []*types.Message) error {
-	for _, message := range messages {
-		routeMessage := types.NewRouteMessage(message)
-		if err := ms.StoreMessage(routeMessage); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (ms *MessageStore) GetMessage(messageKey types.MessageKey) (*types.RouteMessage, error) {
 	v, err := ms.db.GetByKey(GetKey([]string{ms.prefix, messageKey.Src, fmt.Sprintf("%d", messageKey.Sn)}))
 	if err != nil {


### PR DESCRIPTION
To prevent message loss when the application crashes at the time of relaying messages, messages are first stored in the database before being added to the in-memory message cache. This is because when the application restarts, the in-memory cache is cleared, leading to the potential loss of unprocessed messages since the relay resumes from the last saved block height.